### PR TITLE
Clustering II

### DIFF
--- a/Commons/src/main/java/hk/hku/cecid/piazza/commons/net/HostInfo.java
+++ b/Commons/src/main/java/hk/hku/cecid/piazza/commons/net/HostInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) 2005 Center for E-Commerce Infrastructure Development, The
+ * University of Hong Kong (HKU). All Rights Reserved.
+ *
+ * This software is licensed under the GNU GENERAL PUBLIC LICENSE Version 2.0 [1]
+ *
+ * [1] http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+ */
+
+package hk.hku.cecid.piazza.commons.net;
+
+import java.net.InetAddress;
+
+/**
+ */
+public final class HostInfo {
+
+    /**
+     * Get the ip address of this host
+     */
+    public static String GetLocalhostAddress() {
+	String localHostAddress = "";
+	try {
+	    InetAddress localAddr = InetAddress.getLocalHost();
+	    localHostAddress = localAddr.getHostAddress();
+	} catch (Exception e) {
+	    localHostAddress = "no_host";
+	}
+	return localHostAddress;
+    }
+}

--- a/Dist/src/main/scripts/sql/ebms.sql
+++ b/Dist/src/main/scripts/sql/ebms.sql
@@ -26,6 +26,7 @@ CREATE TABLE message (
 	timeout_time_stamp timestamp,
 	status varchar,
 	status_description varchar,
+	hostname varchar,
 	PRIMARY KEY (message_id, message_box)
 );
 
@@ -41,12 +42,14 @@ CREATE TABLE repository (
 CREATE TABLE outbox (
 	message_id varchar,
 	retried integer,
+	hostname varchar,
 	PRIMARY KEY (message_id)
 );
 
 CREATE TABLE inbox (
 	message_id varchar,
 	order_no bigint,
+	hostname varchar,
 	PRIMARY KEY (message_id)
 );
 

--- a/Dist/src/main/scripts/sql/ebms.sql
+++ b/Dist/src/main/scripts/sql/ebms.sql
@@ -81,4 +81,11 @@ CREATE TABLE partnership (
 	PRIMARY KEY (partnership_id)
 );
 
+CREATE TABLE cluster (
+	hostname varchar,
+	status varchar,
+	timestamp bigint,
+	PRIMARY KEY (hostname)
+);
+
 CREATE SEQUENCE inbox_order_no_seq;

--- a/Dist/src/main/scripts/sql/mysql_ebms.sql
+++ b/Dist/src/main/scripts/sql/mysql_ebms.sql
@@ -26,6 +26,7 @@ CREATE TABLE message (
 	timeout_time_stamp timestamp null default null,
 	status varchar(2),
 	status_description varchar(4000),
+	hostname varchar(255),
 	PRIMARY KEY (message_id, message_box)
 )ENGINE= INNODB;
 
@@ -41,12 +42,14 @@ CREATE TABLE repository (
 CREATE TABLE outbox (
 	message_id varchar(255),
 	retried integer,
+	hostname varchar(255),
 	PRIMARY KEY (message_id)
 )ENGINE= INNODB;
 
 CREATE TABLE inbox (
 	message_id varchar(255),
 	order_no bigint,
+	hostname varchar(255),
 	PRIMARY KEY (message_id)
 )ENGINE= INNODB;
 
@@ -76,4 +79,11 @@ CREATE TABLE partnership (
 	encrypt_cert LONGBLOB,
 	encrypt_algorithm varchar(5),
 	PRIMARY KEY (partnership_id)
+)ENGINE= INNODB;
+
+CREATE TABLE cluster (
+	hostname varchar(255),
+	status varchar(12),
+	timestamp bigint,
+	PRIMARY KEY (hostname)
 )ENGINE= INNODB;

--- a/Dist/src/main/scripts/sql/oracle_ebms.sql
+++ b/Dist/src/main/scripts/sql/oracle_ebms.sql
@@ -26,6 +26,7 @@ CREATE TABLE message (
 	timeout_time_stamp timestamp,
 	status varchar2(2),
 	status_description varchar2(4000),
+	hostname varchar2(255),
 	PRIMARY KEY (message_id, message_box)
 );
 
@@ -41,12 +42,14 @@ CREATE TABLE repository (
 CREATE TABLE outbox (
 	message_id varchar2(255),
 	retried integer,
+	hostname varchar2(255),
 	PRIMARY KEY (message_id)
 );
 
 CREATE TABLE inbox (
 	message_id varchar2(255),
 	order_no number,
+	hostname varchar2(255),
 	PRIMARY KEY (message_id)
 );
 
@@ -76,6 +79,13 @@ CREATE TABLE partnership (
 	encrypt_cert blob,
 	encrypt_algorithm varchar2(5),
 	PRIMARY KEY (partnership_id)
+);
+
+CREATE TABLE cluster (
+	hostname varchar2(255),
+	status varchar2(12),
+	timestamp number,
+	PRIMARY KEY (hostname)
 );
 
 CREATE SEQUENCE inbox_order_no_seq;

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDAO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDAO.java
@@ -1,0 +1,39 @@
+/* 
+ * Copyright(c) 2005 Center for E-Commerce Infrastructure Development, The
+ * University of Hong Kong (HKU). All Rights Reserved.
+ *
+ * This software is licensed under the GNU GENERAL PUBLIC LICENSE Version 2.0 [1]
+ * 
+ * [1] http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+ */
+
+package hk.hku.cecid.ebms.spa.dao;
+
+import hk.hku.cecid.piazza.commons.dao.DAO;
+import hk.hku.cecid.piazza.commons.dao.DAOException;
+
+import java.util.List;
+
+/**
+ * @author Hans Sinnige
+ * 
+ */
+public interface ClusterDAO extends DAO {
+    public boolean findCluster(ClusterDVO data) throws DAOException;
+
+    public void addCluster(ClusterDVO data) throws DAOException;
+
+    public boolean updateCluster(ClusterDVO data) throws DAOException;
+
+    public void deleteCluster(ClusterDVO data) throws DAOException;
+    
+    public List selectCluster() throws DAOException;
+
+    public List findClusterEntry(String hostname) throws DAOException;
+
+    public List findClusterAllEntries() throws DAOException;
+
+    public List findClusterStatusEntries(String status) throws DAOException;
+
+    public List findClusterLatestTimestamp() throws DAOException;
+}

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDVO.java
@@ -1,0 +1,50 @@
+/* 
+ * Copyright(c) 2005 Center for E-Commerce Infrastructure Development, The
+ * University of Hong Kong (HKU). All Rights Reserved.
+ *
+ * This software is licensed under the GNU GENERAL PUBLIC LICENSE Version 2.0 [1]
+ * 
+ * [1] http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+ */
+
+package hk.hku.cecid.ebms.spa.dao;
+
+import hk.hku.cecid.piazza.commons.dao.DVO;
+
+/**
+ * @author Hans Sinnige
+ * 
+ */
+public interface ClusterDVO extends DVO {
+
+    /**
+     * @param Returns the hostname.
+     */
+    public String getHostname();
+
+    /**
+     * @param hostname The hostname to set.
+     */
+    public void setHostname(String hostname);
+
+    /**
+     * @return Returns the status.
+     */
+    public String getStatus();
+
+    /**
+     * @param status The status to set.
+     */
+    public void setStatus(String status);
+
+    /**
+     * @return Returns the timestamp.
+     */
+    public long getTimestamp();
+
+    /**
+     * @param timestamp The timestamp to set.
+     */
+    public void setTimestamp(long timestamp);
+
+}

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDataSourceDAO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDataSourceDAO.java
@@ -1,0 +1,95 @@
+/* 
+ * Copyright(c) 2005 Center for E-Commerce Infrastructure Development, The
+ * University of Hong Kong (HKU). All Rights Reserved.
+ *
+ * This software is licensed under the GNU GENERAL PUBLIC LICENSE Version 2.0 [1]
+ * 
+ * [1] http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+ */
+
+package hk.hku.cecid.ebms.spa.dao;
+
+import hk.hku.cecid.piazza.commons.dao.DVO;
+import hk.hku.cecid.piazza.commons.dao.DAOException;
+import hk.hku.cecid.piazza.commons.dao.ds.DataSourceDAO;
+
+import java.util.List;
+
+/**
+ * @author Hans Sinnige
+ * 
+ */
+public class ClusterDataSourceDAO extends DataSourceDAO implements ClusterDAO {
+
+    public DVO createDVO() {
+        return new ClusterDataSourceDVO();
+    }
+
+    public boolean findCluster(ClusterDVO data) throws DAOException {
+        return super.retrieve((ClusterDataSourceDVO) data);
+    }
+
+    public void addCluster(ClusterDVO data) throws DAOException {
+        super.create((ClusterDataSourceDVO) data);
+    }
+
+    public boolean updateCluster(ClusterDVO data) throws DAOException {
+        return super.persist((ClusterDataSourceDVO) data);
+    }
+
+    public void deleteCluster(ClusterDVO data) throws DAOException {
+        super.remove((ClusterDataSourceDVO) data);
+    }
+    
+    public List selectCluster() throws DAOException {
+        return super.find("select_cluster", new Object[]{});
+    }
+
+
+    /**
+     * findClusterEntry() - get the entry with value hostname from the
+     * table cluster
+     *
+     * @param hostname The hostname for which the search is done
+     *
+     * @return List of Cluster entries (1)
+     */
+    public List findClusterEntry(String hostname) throws DAOException {
+	if (hostname == null)
+	    throw new DAOException("The required param 'hostname' is missing.");
+        return super.find( "find_cluster_entry", new Object[] { hostname });
+    }
+
+    /**
+     * findClusterAllEntries() - get all entries inside the table cluster
+     *
+     * @return List of Cluster entries
+     */
+    public List findClusterAllEntries() throws DAOException {
+        return super.find( "find_cluster_all_entries", new Object[] {});
+    }
+
+    /**
+     * findClusterStatusEntries() - get all entries from the table cluster
+     * with attribute status set to given values
+     *
+     * @param status The status for which the search is done
+     *
+     * @return List of Cluster entries
+     */
+    public List findClusterStatusEntries(String status) throws DAOException {
+	if (status == null)
+	    throw new DAOException("The required param 'status' is missing.");
+        return super.find( "find_cluster_status_entries", new Object[] { status });
+    }
+
+    /**
+     * findClusterLatestTimestamp() - Find the entry with the highest / latest
+     * timestamp
+     *
+     * @return List of Cluster entries (1)
+     */
+   public List findClusterLatestTimestamp() throws DAOException {
+        return super.find( "find_cluster_latest_timestamp", new Object[] {});
+    }
+}

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDataSourceDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/ClusterDataSourceDVO.java
@@ -1,0 +1,67 @@
+/* 
+ * Copyright(c) 2005 Center for E-Commerce Infrastructure Development, The
+ * University of Hong Kong (HKU). All Rights Reserved.
+ *
+ * This software is licensed under the GNU GENERAL PUBLIC LICENSE Version 2.0 [1]
+ * 
+ * [1] http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+ */
+
+package hk.hku.cecid.ebms.spa.dao;
+
+import hk.hku.cecid.piazza.commons.dao.ds.DataSourceDVO;
+
+/**
+ * @author Hans Sinnige
+ */
+public class ClusterDataSourceDVO extends DataSourceDVO implements
+        ClusterDVO {
+
+    public ClusterDataSourceDVO() {
+        super();
+    }
+
+    /**
+     * @return The hostname
+     */
+    public String getHostname() {
+        return super.getString("hostname");
+    }
+
+    /**
+     * @param hostname The hostname to set.
+     */
+    public void setHostname(String hostname) {
+        super.setString("hostname", hostname);
+    }
+
+    /**
+     * @return The status
+     */
+    public String getStatus() {
+        return super.getString("status");
+    }
+
+    /**
+     * @param status The status to set.
+     */
+    public void setStatus(String status) {
+        super.setString("status", status);
+    }
+
+    /**
+     * @return The timestamp
+     */
+    public long getTimestamp() {
+        return super.getLong("timestamp");
+    }
+
+    /**
+     * @param timestamp The timestamp to set.
+     */
+    public void setTimestamp(long timestamp) {
+        super.setLong("timestamp", timestamp);
+    }
+
+
+}

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/InboxDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/InboxDVO.java
@@ -31,4 +31,8 @@ public interface InboxDVO extends DVO {
     
     public void setOrderNo(long orderNo);
 
+    public String getHostname();
+
+    public void setHostname(String hostname);
+
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/InboxDataSourceDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/InboxDataSourceDVO.java
@@ -59,4 +59,22 @@ public class InboxDataSourceDVO extends DataSourceDVO implements
         super.setLong("orderNo", orderNo);
     }
 
+    /*
+     * (non-Javadoc)
+     *
+     * @see hk.hku.cecid.ebms.spa.dao.RepositoryDVO#getHostname()
+     */
+    public String getHostname() {
+        return super.getString("hostname");
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see hk.hku.cecid.ebms.spa.dao.RepositoryDVO#setHostname(java.lang.String)
+     */
+    public void setHostname(String hostname) {
+        super.setString("hostname", hostname);
+    }
+
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDAO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDAO.java
@@ -11,6 +11,7 @@ package hk.hku.cecid.ebms.spa.dao;
 
 import java.util.List;
 import java.util.Date;
+import java.sql.Timestamp;
 
 import hk.hku.cecid.piazza.commons.dao.DAO;
 import hk.hku.cecid.piazza.commons.dao.DAOException;
@@ -85,4 +86,8 @@ public interface MessageDAO extends DAO {
      * @see hk.hku.cecid.ebms.spa.dao.MessageDVO#setTimeoutTimestamp(java.sql.Timestamp)
      */
     public int updateTimedOutMessageStatus(String status, Date currentTime) throws DAOException;
+
+    public int updateOldIncomingMessagesPendingbyTimestamp(String newhostname, String oldhostname) throws DAOException;
+    public int updateOldOutboxPendingMessagesbyTimestamp(String newhostname, String oldhostname) throws DAOException;
+    public int updateOldOutboxProcessingMessagesbyTimestamp(String newhostname, String oldhostname) throws DAOException;
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDVO.java
@@ -281,4 +281,9 @@ public interface MessageDVO extends DVO {
     public void setPartnershipId(String partnershipId);
     
     public String getPartnershipId();
+
+    public String getHostname();
+
+    public void setHostname(String hostname);
+
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDAO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDAO.java
@@ -336,11 +336,6 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
     		parameters.add(data.getConvId());
     	}
     	
-    	if (data.getPrimalMessageId() != null && !data.getPrimalMessageId().trim().equals("")) {
-    		sql += " AND " + getFilter("find_message_by_history_filter_primal_message_id");
-    		parameters.add(data.getPrimalMessageId());
-    	}
-    	
 		sql += " " + getOrder("find_message_by_history_order");
     	parameters.add(new Integer(numberOfMessage));
     	parameters.add(new Integer(offset));
@@ -394,11 +389,6 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
         		sql += " AND " + getFilter("find_number_of_message_by_history_filter_conv_id");
         		parameters.add(data.getConvId());
         	}
-        	
-        	if (data.getPrimalMessageId() != null && !data.getPrimalMessageId().trim().equals("")) {
-        		sql += " AND " + getFilter("find_number_of_message_by_history_filter_primal_message_id");
-        		parameters.add(data.getPrimalMessageId());
-        	}        	
 
     		List queryResult = executeRawQuery(sql, parameters.toArray());
             List resultEntry = (List) queryResult.get(0);
@@ -430,4 +420,41 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
 		// Execute the update
 		return this.executeUpdate(this.getSQL("updated_timed_out_message_status"), new Object[]{status, ts});
 	}    
+
+    /**
+     *
+     */
+    public int updateOldIncomingMessagesPendingbyTimestamp(String newhostname, String oldhostname) throws DAOException {
+	if (newhostname == null || oldhostname == null) {
+	    throw new DAOException("The required params is missing.");
+	}
+
+	// Execute the update
+	return this.executeUpdate(this.getSQL("update_old_incoming_messages_pending_by_timestamp"), new Object[]{newhostname, oldhostname});
+    }
+
+    /**
+     *
+     */
+    public int updateOldOutboxPendingMessagesbyTimestamp(String newhostname, String oldhostname) throws DAOException {
+	if (newhostname == null || oldhostname == null) {
+	    throw new DAOException("The required params is missing.");
+	}
+
+	// Execute the update
+	return this.executeUpdate(this.getSQL("update_old_outbox_pending_messages_by_timestamp"), new Object[]{newhostname, oldhostname});
+    }
+
+    /**
+     *
+     */
+    public int updateOldOutboxProcessingMessagesbyTimestamp(String newhostname, String oldhostname) throws DAOException {
+	if (newhostname == null || oldhostname == null) {
+	    throw new DAOException("The required params is missing.");
+	}
+
+	// Execute the update
+	return this.executeUpdate(this.getSQL("update_old_outbox_processing_messages_by_timestamp"), new Object[]{newhostname, oldhostname});
+    }
+
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDAO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDAO.java
@@ -101,7 +101,7 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
      */
     public List findInboxPendingMessagesByTimestamp(MessageDVO data) throws DAOException {
     	return super.find("find_inbox_pending_messages_by_timestamp",
-    			new Object[] {});
+			  new Object[] {data.getHostname()});
     }
 	
     /**
@@ -115,7 +115,7 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
      */
     public List findOutboxPendingMessagesByTimestamp(MessageDVO data) throws DAOException {
     	return super.find("find_outbox_pending_messages_by_timestamp",
-    			new Object[] {});
+			  new Object[] {data.getHostname()});
     }
 
     /**
@@ -129,7 +129,7 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
      */
     public List findOutboxProcessingMessagesByTimestamp(MessageDVO data) throws DAOException {
     	return super.find("find_outbox_processing_messages_by_timestamp",
-    			new Object[] {});
+			  new Object[] {data.getHostname()});
     }
 
     /**

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDAO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDAO.java
@@ -335,7 +335,12 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
     		sql += " AND " + getFilter("find_message_by_history_filter_conv_id");
     		parameters.add(data.getConvId());
     	}
-    	
+
+	if (data.getPrimalMessageId() != null && !data.getPrimalMessageId().trim().equals("")) {
+	    sql += " AND " + getFilter("find_message_by_history_filter_primal_message_id");
+	    parameters.add(data.getPrimalMessageId());
+        }
+
 		sql += " " + getOrder("find_message_by_history_order");
     	parameters.add(new Integer(numberOfMessage));
     	parameters.add(new Integer(offset));
@@ -389,6 +394,11 @@ public class MessageDataSourceDAO extends DataSourceDAO implements MessageDAO {
         		sql += " AND " + getFilter("find_number_of_message_by_history_filter_conv_id");
         		parameters.add(data.getConvId());
         	}
+
+		if (data.getPrimalMessageId() != null && !data.getPrimalMessageId().trim().equals("")) {
+		    sql += " AND " + getFilter("find_number_of_message_by_history_filter_primal_message_id");
+		    parameters.add(data.getPrimalMessageId());
+                }
 
     		List queryResult = executeRawQuery(sql, parameters.toArray());
             List resultEntry = (List) queryResult.get(0);

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/MessageDataSourceDVO.java
@@ -446,4 +446,19 @@ public class MessageDataSourceDVO extends DataSourceDVO implements MessageDVO {
     public String getPartnershipId() {
     	return super.getString("partnershipId");
     }
+
+    /**
+     * @return Returns the hostname
+     */
+    public String getHostname() {
+        return super.getString("hostname");
+    }
+
+    /**
+     * @param hostname The hostname to set.
+     */
+    public void setHostname(String hostname) {
+        super.setString("hostname", hostname);
+    }
+
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/OutboxDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/OutboxDVO.java
@@ -37,4 +37,14 @@ public interface OutboxDVO extends DVO {
      */
     public void setRetried(int retried);
 
+    /**
+     * @param Returns the hostname.
+     */
+    public String getHostname();
+
+    /**
+     * @param hostname The hostname to set.
+     */
+    public void setHostname(String hostname);
+
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/OutboxDataSourceDVO.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/dao/OutboxDataSourceDVO.java
@@ -59,4 +59,22 @@ public class OutboxDataSourceDVO extends DataSourceDVO implements
         super.setInt("retried", retried);
     }
 
+    /*
+     * (non-Javadoc)
+     *
+     * @see hk.hku.cecid.ebms.spa.dao.RepositoryDVO#getHostname()
+     */
+    public String getHostname() {
+        return super.getString("hostname");
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see hk.hku.cecid.ebms.spa.dao.RepositoryDVO#setHostname(java.lang.String)
+     */
+    public void setHostname(String hostname) {
+        super.setString("hostname", hostname);
+    }
+
 }

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/InboundMessageProcessor.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/InboundMessageProcessor.java
@@ -30,6 +30,7 @@ import hk.hku.cecid.ebms.spa.listener.EbmsResponse;
 import hk.hku.cecid.ebms.spa.task.AgreementHandler;
 import hk.hku.cecid.piazza.commons.dao.DAOException;
 import hk.hku.cecid.piazza.commons.soap.SOAPRequest;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
 
 import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateFactory;
@@ -1807,6 +1808,7 @@ public class InboundMessageProcessor {
 
 		try {
 			MessageDVO messageDVO = message.getMessageDVO();
+			messageDVO.setHostname(HostInfo.GetLocalhostAddress());
 			messageDVO.setStatus(MessageClassifier.INTERNAL_STATUS_PENDING);
 			MessageServerDAO messageServerDAO = (MessageServerDAO) EbmsProcessor.core.dao
 					.createDAO(MessageServerDAO.class);
@@ -1835,6 +1837,7 @@ public class InboundMessageProcessor {
 
 		try {
 			MessageDVO messageDVO = message.getMessageDVO();
+			messageDVO.setHostname(HostInfo.GetLocalhostAddress());
 			messageDVO.setStatus(MessageClassifier.INTERNAL_STATUS_PROCESSED);
 			messageDVO.setStatusDescription("Message was sent synchronously");
 			MessageServerDAO messageServerDAO = (MessageServerDAO) EbmsProcessor.core.dao

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/OutboundMessageProcessor.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/OutboundMessageProcessor.java
@@ -30,6 +30,7 @@ import hk.hku.cecid.piazza.commons.message.Message;
 import hk.hku.cecid.piazza.commons.soap.SOAPRequest;
 import hk.hku.cecid.piazza.commons.soap.WebServicesRequest;
 import hk.hku.cecid.piazza.commons.util.Generator;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
 
 import java.util.Iterator;
 import java.util.List;
@@ -249,6 +250,7 @@ public class OutboundMessageProcessor {
 			repositoryDVO.setContentType(contentType);
 		}
 		OutboxDVO outboxDVO = message.getOutboxDVO();
+		outboxDVO.setHostname(HostInfo.GetLocalhostAddress());
 
 		MessageServerDAO messageServerDAO = (MessageServerDAO) EbmsProcessor.core.dao
 				.createDAO(MessageServerDAO.class);
@@ -325,8 +327,10 @@ public class OutboundMessageProcessor {
 		if (contentType != null) {
 			repositoryDVO.setContentType(contentType);
 		}
+		OutboxDVO outboxDVO = message.getOutboxDVO();
+		outboxDVO.setHostname(HostInfo.GetLocalhostAddress());
 
-		dao.storeOutboxMessage(messageDVO, repositoryDVO, message.getOutboxDVO(), primalMsgDVO);
+		dao.storeOutboxMessage(messageDVO, repositoryDVO, outboxDVO, primalMsgDVO);
 
 		EbmsProcessor.core.log.info("Store outgoing message: "
 				+ ebxmlRequestMessage.getMessageId());

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/ClusterAudit.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/ClusterAudit.java
@@ -1,0 +1,380 @@
+package hk.hku.cecid.ebms.spa.task;
+
+import java.net.*;
+import java.io.*;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.sql.Timestamp;
+
+import hk.hku.cecid.piazza.commons.dao.DAOException;
+import hk.hku.cecid.piazza.commons.module.ActiveModule;
+import hk.hku.cecid.piazza.commons.module.ModuleException;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
+
+import hk.hku.cecid.ebms.spa.EbmsProcessor;
+import hk.hku.cecid.ebms.spa.dao.MessageDAO;
+import hk.hku.cecid.ebms.spa.dao.MessageDVO;
+import hk.hku.cecid.ebms.spa.dao.ClusterDAO;
+import hk.hku.cecid.ebms.spa.dao.ClusterDVO;
+import hk.hku.cecid.ebms.spa.handler.MessageClassifier;
+
+/**
+ * The <code>ClusterAudit</code> audits messages in the cluster and redistributes them if needed
+ *
+ * It uses the table cluster inside the database to determine which hosts are part of the cluster
+ * and to find out if it should wait for or start to audit the hosts and when needed their related
+ * messages.
+ * 
+ * Creation Date: 25/11/2014
+ * 
+ * @author 	Hans Sinnige
+ * @version	1.0.0
+ * 
+ */
+public class ClusterAudit extends ActiveModule {
+	
+    // Internal Message DAO object. 
+    private MessageDAO msgDAO;
+    private ClusterDAO clusterDAO;
+ 
+    // The flag for initializing monitor related objects.
+    private boolean initialized = false;
+ 
+    // Our current hostname
+    private static String Hostname;
+
+    // Static properties, values are set inside ebms.properties.xml under <cluster>
+    private static int Interval = 180000;
+    private static String Servlet = "/corvus/httpd/ebms/inbound/";
+    private static String Port = "8080";
+    private static int Timeout = 10000;
+
+    /**
+     * Creates a new instance of MessageMonitor.
+     * 
+     * @param descriptorLocation the module descriptor.
+     * @param loader the class loader for this module.
+     * @param shouldInitialize true if the module should be initialized.
+     */
+    public ClusterAudit(String descriptorLocation, ClassLoader loader, boolean shouldInitialize) {
+	super(descriptorLocation, loader, shouldInitialize);
+    }
+    
+    /**
+     * Invoke for initialization.
+     */
+    public void init() {
+	super.init();
+    }
+    
+    /**
+     * Post/Lazy initialization. This method is invoked at the firs time only
+     * this module execute.<br/><br/>
+     * 
+     * Initialize all class data and register this host in the cluster list.
+     */
+    public void initialize(){
+	try{
+	    msgDAO = (MessageDAO) EbmsProcessor.core.dao.createDAO(MessageDAO.class);
+	    clusterDAO = (ClusterDAO) EbmsProcessor.core.dao.createDAO(ClusterDAO.class);
+	    
+	    this.Servlet = EbmsProcessor.core.properties.getProperty("/ebms/cluster/servlet");
+	    this.Port = EbmsProcessor.core.properties.getProperty("/ebms/cluster/port");
+	    this.Interval = Integer.parseInt(EbmsProcessor.core.properties.getProperty("/ebms/cluster/interval"));
+	    this.Timeout = Integer.parseInt(EbmsProcessor.core.properties.getProperty("/ebms/cluster/connectiontimeout"));
+	    this.Hostname = HostInfo.GetLocalhostAddress();
+	    
+	    registerCurrentHost();
+	    this.initialized = true;
+	}catch(DAOException daoe){
+	    EbmsProcessor.core.log.fatal("ClusterAudit: Unable to intialize." + daoe);
+	}
+    }
+    
+    /**
+     * The method is invoked constantly with interval defined in the configuration
+     * descriptor or 60 second by default.
+     * 
+     * @return true if this method should be invoked again after a defined interval.
+     */
+    public boolean execute() {
+	// Lazy initialization. 
+	if (!this.initialized)
+	    this.initialize();
+	
+	int counter = 0;
+	
+	try {
+	    long timeStamp = getHostTimestamp(Hostname);
+	    String oldHostname = "";
+	    Date date = new Date();
+	    long currentTimestamp = date.getTime();
+	    
+	    // Check if audit starttime is passed or not
+	    if (timeStamp > currentTimestamp) {
+		date.setTime( timeStamp );
+		EbmsProcessor.core.log.debug ( "ClusterAudit: wait (" + date.toString() + ")");
+	    } else {
+		EbmsProcessor.core.log.debug ( "ClusterAudit: start (" + date.toString() + ")");
+		// To prevent more hosts auditing the cluster at the same time the
+		// status of our host is set to auditor. Then the cluster is checked
+		// if this is the only auditor in the cluster. In case this is the
+		// only auditor the audit will start. In case it is not the only
+		// auditor the audit will be skipped and this host will be added
+		// at the end of the cluster list.
+		updateStatusHostname( Hostname, "auditor" );
+		if (uniqueAuditor(Hostname)) {
+		    // Walk through the list of hosts inside this cluster
+		    List clusterDVOList = clusterDAO.findClusterAllEntries();
+		    Iterator i = clusterDVOList.iterator();
+		    while (i.hasNext()) {
+			ClusterDVO clusterEntry = (ClusterDVO) i.next();
+			oldHostname = clusterEntry.getHostname();
+			EbmsProcessor.core.log.debug ( "ClusterAudit: check host: " + oldHostname );
+			counter = 0;
+			// Skip this host and check if the host is available
+			if (!oldHostname.equals(Hostname) && !hostIsAvailable(oldHostname)) {
+			    EbmsProcessor.core.log.debug ( "ClusterAudit: host no longer available: " + oldHostname );
+			    // Replace hostname for those messages that are still related to the other host
+			    counter = replaceHostname( Hostname, oldHostname );
+			    if (counter == 0) {
+				// If there are no messages left in the other host remove it from the cluster list
+				EbmsProcessor.core.log.debug ( "ClusterAudit: remove host: " + oldHostname );
+				removeHostname( oldHostname );
+			    } else {
+				// Update the status of the host to inactive
+				EbmsProcessor.core.log.debug ( "ClusterAudit: inactive host: " + oldHostname + " message(s) moved" );
+				updateStatusHostname( oldHostname, "inactive" );
+			    }
+			}
+		    }
+		}
+		// Put us at the end of the cluster list
+		registerCurrentHost();
+		EbmsProcessor.core.log.debug ( "ClusterAudit: end (" + date.toString() + ")");
+	    }
+	}catch(DAOException daoe){
+	    EbmsProcessor.core.log.fatal("ClusterAudit: Unable to complete cluster audit." + daoe);
+	}
+	return true;
+    }
+
+    /**
+     * getHostTimestamp() - retrieves the value of attribute timestamp from
+     * the database table 'cluster' for the provided host
+     *
+     * @param hostname the host for which information is requested
+     *
+     * @return timeStamp value of the provided host, or 0 in case the host isn't found
+     */
+    private long getHostTimestamp(String hostname) throws DAOException {
+	long timeStamp = 0;
+	List clusterDVOList = clusterDAO.findClusterEntry(hostname);
+	Iterator i = clusterDVOList.iterator();
+	while (i.hasNext()) {
+	    ClusterDVO clusterEntry = (ClusterDVO) i.next();
+	    timeStamp = clusterEntry.getTimestamp();
+	}
+	return timeStamp;
+    }
+    
+    /**
+     * getLatestClusterTimestamp() - retrieves the 'highest' value of attribute
+     * timestamp from database table cluster.
+     *
+     * @return timeStamp value of the provided host, or 0 in case there is no
+     * value found.
+     */
+    private long getLatestClusterTimestamp() throws DAOException {
+	long timeStamp = 0;
+	List clusterDVOList = clusterDAO.findClusterLatestTimestamp();
+	Iterator i = clusterDVOList.iterator();
+	while (i.hasNext()) {
+	    ClusterDVO clusterEntry = (ClusterDVO) i.next();
+	    timeStamp = clusterEntry.getTimestamp();
+	}
+	return timeStamp;
+    }
+
+    /**
+     * getLatestTimestamp() - retrieves the 'highest' value of timestamp. The
+     * value is based upon the highest value from database table 'cluster' but
+     * in case that value is lower than the current time or in case the cluster
+     * is empty the current time is returned as timestamp.
+     *
+     * @return timeStamp value 
+     */
+    private long getLatestTimestamp() throws DAOException {
+	long timeStamp = getLatestClusterTimestamp();
+	Date currentDate = new Date();
+	long currentTimeStamp = currentDate.getTime();
+	if (currentTimeStamp > timeStamp) {
+	    timeStamp = currentTimeStamp;
+	}
+	return timeStamp;
+    }
+
+    /**
+     * removeHostname() - removes given host from database table cluster
+     *
+     * @param hostname the host to be removed
+     */
+    private void removeHostname( String hostname ) throws DAOException {
+	// Check if an entry for our host exist and preset all values
+	ClusterDVO clusterDVO = (ClusterDVO) clusterDAO.createDVO();
+	clusterDVO.setHostname(hostname);
+	clusterDAO.deleteCluster(clusterDVO);
+    }
+
+    /**
+     * updateStatusHostname() - update the status of given host in
+     * database table cluster
+     *
+     * @param hostname the host to be updated
+     * @param status the new status value
+     *
+     */
+    private void updateStatusHostname( String hostname, String status ) throws DAOException {
+	ClusterDVO clusterDVO = (ClusterDVO) clusterDAO.createDVO();
+	clusterDVO.setHostname(hostname);
+	clusterDVO.setStatus(status);
+	clusterDAO.updateCluster(clusterDVO);
+    }
+
+    /**
+     * updateClusterData() - update the data of given host in
+     * database table cluster. In case the host is unknown in the
+     * table cluster a new entry will be added with given values
+     *
+     * @param hostname the host to be updated
+     * @param status the status value
+     * @param timestamp the timestamp value
+     *
+     */
+    private void updateClusterData(String hostname, String status, long timestamp) throws DAOException {
+	// Check if an entry for our host exist and preset all values
+	ClusterDVO clusterDVO = (ClusterDVO) clusterDAO.createDVO();
+	clusterDVO.setHostname(hostname);
+	if (clusterDAO.findCluster(clusterDVO)) {
+	    // Update host entry
+	    clusterDVO.setHostname(hostname);
+	    clusterDVO.setStatus(status);
+	    clusterDVO.setTimestamp(timestamp);
+	    clusterDAO.updateCluster(clusterDVO);
+	} else {
+	    // Insert host entry
+	    clusterDVO.setHostname(hostname);
+	    clusterDVO.setStatus(status);
+	    clusterDVO.setTimestamp(timestamp);
+	    clusterDAO.addCluster(clusterDVO);
+	}
+    }
+
+    /**
+     * registerCurrentHost() - Add the current host to the database
+     * table cluster with an active status and up to date timestamp.
+     * In case the host already exist inside cluster its data will
+     * be updated.
+     *
+     */
+    private void registerCurrentHost() throws DAOException {
+	// Retrieve the latest registrated timestamp from the cluster
+	long timeStamp = getLatestTimestamp();
+	timeStamp += Interval;
+	
+	// Update or add entry to the cluster table
+	updateClusterData(Hostname, "active", timeStamp);
+    }
+    
+    /**
+     * hostIsAvailable() - Checks if a given host is still available for receiving
+     * messages. This is done by connecting to that host via its inbound servlet.
+     *
+     * @param hostname the host which is tried 
+     *
+     * @return true in case host is available
+     */
+    private boolean hostIsAvailable(String hostname) {
+	boolean available = true;
+	int response;
+	String URLName = "http://" + hostname + ":" + Port + Servlet;
+
+	try {
+	    HttpURLConnection con = (HttpURLConnection) new URL(URLName).openConnection();
+	    con.setRequestMethod("HEAD");
+	    con.setRequestProperty("Connection","close");
+	    con.setConnectTimeout( Timeout );
+	    con.setReadTimeout( Timeout );
+	    response = con.getResponseCode();
+	    if (response == HttpURLConnection.HTTP_OK) {
+		available = true;
+	    } else {
+		available = false;
+	    }
+	}
+	catch (Exception e) {
+	    available = false;
+	}
+	return available;
+    }
+	
+    /**
+     * uniqueAuditor() - Is this host the only auditor
+     *
+     * @param hostname the host which is tried
+     *
+     * @return true in case the host is the unique auditor
+     */
+    private boolean uniqueAuditor(String hostname) throws DAOException {
+	boolean unique = true;
+	String localHostname = "";
+	List clusterDVOList = clusterDAO.findClusterStatusEntries("auditor");
+
+	Iterator i = clusterDVOList.iterator();
+	while (i.hasNext()) {
+	    ClusterDVO clusterEntry = (ClusterDVO) i.next();
+	    localHostname = clusterEntry.getHostname();
+	    if (!localHostname.equals(hostname) && hostIsAvailable(localHostname)) {
+		unique = false;
+	    }
+	}
+	return unique;
+    }
+	
+    /**
+     * replaceHostname() - replace the hostname in case messages are 'stuck'
+     *
+     * @param newhostname the host which will replace the old 
+     * @param oldhostname the host which will be replace by the new 
+     *
+     * @return number of messages by which the hostname is replaced
+     */
+    private int replaceHostname(String newhostname, String oldhostname) throws DAOException {
+	int totcounter = 0;
+	int counter = 0;
+
+	counter = msgDAO.updateOldIncomingMessagesPendingbyTimestamp(newhostname, oldhostname);
+	if (counter > 0) {
+	    EbmsProcessor.core.log.debug ( "ClusterAudit: inbox message(s) recovered.");
+	}
+	totcounter += counter;
+	counter = 0;
+
+	counter = msgDAO.updateOldOutboxPendingMessagesbyTimestamp(newhostname, oldhostname);
+	if (counter > 0) {
+	    EbmsProcessor.core.log.debug ( "ClusterAudit: pending outbox message(s) recovered.");
+	}
+	totcounter += counter;
+	counter = 0;
+
+	counter = msgDAO.updateOldOutboxProcessingMessagesbyTimestamp(newhostname, oldhostname);
+	if (counter > 0) {
+	    EbmsProcessor.core.log.debug ( "ClusterAudit: processing outbox message(s) recovered.");
+	}
+	totcounter += counter;
+
+	return totcounter;
+    }
+}

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/InboxCollector.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/InboxCollector.java
@@ -15,6 +15,7 @@ import hk.hku.cecid.ebms.spa.dao.MessageDAO;
 import hk.hku.cecid.ebms.spa.dao.MessageDVO;
 import hk.hku.cecid.piazza.commons.dao.DAOException;
 import hk.hku.cecid.piazza.commons.module.ActiveTaskList;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
 
 import java.util.Iterator;
 import java.util.List;
@@ -39,6 +40,7 @@ public class InboxCollector extends ActiveTaskList {
 
             // get all the pending message and sort by sequence number
             MessageDVO finderDVO = (MessageDVO) dao.createDVO();
+	    finderDVO.setHostname(HostInfo.GetLocalhostAddress());
 
             List messageDVOList = dao.findInboxPendingMessagesByTimestamp(finderDVO);
             

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/InboxTask.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/InboxTask.java
@@ -20,6 +20,7 @@ import hk.hku.cecid.ebms.spa.handler.MessageClassifier;
 import hk.hku.cecid.piazza.commons.dao.DAOException;
 import hk.hku.cecid.piazza.commons.module.ActiveTask;
 import hk.hku.cecid.piazza.commons.util.StringUtilities;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
 
 /**
  * @author Donahue Sze
@@ -54,6 +55,7 @@ public class InboxTask implements ActiveTask {
             InboxDVO inboxDVO = (InboxDVO) inboxDAO.createDVO();
             inboxDVO.setMessageId(message.getMessageId());
             inboxDVO.setOrderNo(nextOrderNo);
+	    inboxDVO.setHostname(HostInfo.GetLocalhostAddress());
             inboxDAO.create(inboxDVO);
 			
 			fireEvent();

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/OutboxCollector.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/OutboxCollector.java
@@ -15,6 +15,7 @@ import hk.hku.cecid.ebms.spa.dao.MessageDVO;
 import hk.hku.cecid.ebms.spa.handler.MessageClassifier;
 import hk.hku.cecid.piazza.commons.dao.DAOException;
 import hk.hku.cecid.piazza.commons.module.ActiveTaskList;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
 
 import java.util.Iterator;
 import java.util.List;
@@ -34,13 +35,13 @@ public class OutboxCollector extends ActiveTaskList {
      * @see hk.hku.cecid.piazza.commons.module.ActiveTaskList#getTaskList()
      */
     public List getTaskList() {
-
         List messageList = new Vector();
 
         try {
             MessageDAO dao = (MessageDAO) EbmsProcessor.core.dao
                     .createDAO(MessageDAO.class);
             MessageDVO finderDVO = (MessageDVO) dao.createDVO();
+	    finderDVO.setHostname(HostInfo.GetLocalhostAddress());
 
             // get all the processing message in first time
             if (isFirstTime) {

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/OutboxTask.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/task/OutboxTask.java
@@ -34,6 +34,7 @@ import hk.hku.cecid.piazza.commons.security.TrustedHostnameVerifier;
 import hk.hku.cecid.piazza.commons.soap.SOAPHttpConnector;
 import hk.hku.cecid.piazza.commons.soap.SOAPMailSender;
 import hk.hku.cecid.piazza.commons.util.StringUtilities;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -498,6 +499,7 @@ public class OutboxTask implements ActiveTask {
                 OutboxDVO outboxDVO = (OutboxDVO) outboxDao.createDVO();
                 outboxDVO.setMessageId(mID);            
                 outboxDVO.setRetried(this.attempted + 1);
+		outboxDVO.setHostname(HostInfo.GetLocalhostAddress());
                 outboxDao.updateOutbox(outboxDVO);
             } catch (DAOException daoe){
             	String detail = "Cannont update the retires count (Message id: " + mID + ")";

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/cluster-audit.module.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/cluster-audit.module.xml
@@ -1,0 +1,5 @@
+<module id="ebms.cluster-audit" name="Cluster Audit" version="1.0">
+  <parameters>
+    <parameter name="execution-interval" value="30000" />
+  </parameters>
+</module>

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.dao.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.dao.xml
@@ -47,7 +47,12 @@
 		<parameter type="column" name="service" value="service" />
 		<parameter type="column" name="action" value="action" />
 		<parameter type="column" name="conv_id" value="convId" />
-		<parameter type="column" name="ref_to_message_id" value="refToMessageId" />
+               <!-- The Reference Message ID that the response replies to  -->
+                <parameter type="column" name="ref_to_message_id" value="refToMessageId" />
+                <!-- The Message ID of the message triggered "Resend as new" -->
+                <parameter type="column" name="primal_message_id" value="primalMessageId" />
+                <parameter type="column" name="has_resend_as_new" value="hasResendAsNew" />
+                <parameter type="column" name="partnership_id" value="partnershipId" />
 		<parameter type="column" name="sync_reply" value="syncReply" />
 		<parameter type="column" name="dup_elimination" value="dupElimination" />	
 		<parameter type="column" name="ack_requested" value="ackRequested" />
@@ -94,17 +99,18 @@
 		<!-- only for check the allowance of reset message -->    
 		<parameter type="finder" name="find_ordered_messages_by_message_box_and_cpa_and_status" value="select * from message where message_box=? and cpa_id=? and service=? and action=? and conv_id=? and status=? and sequence_no&lt;&gt;-1 LIMIT 1" />
 		
-		<parameter type="finder" name="find_message_by_history" value="select * from message where message_type = 'Order'" />
+		<parameter type="finder" name="find_message_by_history" value="select * from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
 		<parameter type="filter" name="find_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_message_id" value="message_id LIKE ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_cpa_id" value="cpa_id LIKE ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_service" value="service LIKE ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_action" value="action LIKE ?"/>
-		<parameter type="filter" name="find_message_by_history_filter_conv_id" value="conv_id LIKE ?"/>				
+		<parameter type="filter" name="find_message_by_history_filter_conv_id" value="conv_id LIKE ?"/>	
 		<parameter type="filter" name="find_message_by_history_filter_status" value="status = ?"/>
+		<parameter type="filter" name="find_message_by_history_filter_primal_message_id" value="primal_message_id LIKE ?"/>
 		<parameter type="order" name="find_message_by_history_order" value="order by time_stamp desc, message_box asc LIMIT ? offset ?"/>
 		
-		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where message_type = 'Order'" />
+		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_status" value="status = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_id" value="message_id LIKE ?"/>
@@ -112,6 +118,7 @@
 		<parameter type="filter" name="find_number_of_message_by_history_filter_service" value="service LIKE ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_action" value="action LIKE ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_conv_id" value="conv_id LIKE ?"/>
+		<parameter type="filter" name="find_number_of_message_by_history_filter_primal_message_id" value="primal_message_id LIKE ?"/>
 		<!-- <parameter type="filter" name="find_number_of_message_by_history_filter_status" value="status = ?"/> -->
 		
 		<!-- 

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.dao.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.dao.xml
@@ -47,12 +47,7 @@
 		<parameter type="column" name="service" value="service" />
 		<parameter type="column" name="action" value="action" />
 		<parameter type="column" name="conv_id" value="convId" />
-		<!-- The Reference Message ID that the response replies to  -->
 		<parameter type="column" name="ref_to_message_id" value="refToMessageId" />
-		<!-- The Message ID of the message triggered "Resend as new" -->
-		<parameter type="column" name="primal_message_id" value="primalMessageId" />
-		<parameter type="column" name="has_resend_as_new" value="hasResendAsNew" />
-		<parameter type="column" name="partnership_id" value="partnershipId" />
 		<parameter type="column" name="sync_reply" value="syncReply" />
 		<parameter type="column" name="dup_elimination" value="dupElimination" />	
 		<parameter type="column" name="ack_requested" value="ackRequested" />
@@ -74,7 +69,12 @@
 		<!-- for inbox and outbox collector -->
 		<parameter type="finder" name="find_inbox_pending_messages_by_timestamp" value="select * from message where hostname = ? and message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 50" />
 		<parameter type="finder" name="find_outbox_pending_messages_by_timestamp" value="select * from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
-		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from message,outbox where outbox.hostname = ? outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
+		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
+
+		<!-- for Cluster Audit -->
+		<parameter type="sql" name="update_old_incoming_messages_pending_by_timestamp" value="update message set hostname = ? where message_id in (select message_id from message where hostname = ? and message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 25);" />
+		<parameter type="sql" name="update_old_outbox_pending_messages_by_timestamp" value="update outbox set hostname = ? where message_id in (select message.message_id from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 25)" />
+		<parameter type="sql" name="update_old_outbox_processing_messages_by_timestamp" value="update outbox set hostname = ? where message_id in (select message.message_id from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 25)" />
 
 		<!-- only for Ebms Message Collector Service -->
 		<parameter type="finder" name="find_message_by_cpa" value="select m.* from message m, inbox i where m.message_id = i.message_id and m.cpa_id = ? and m.service = ? and m.action = ? and m.message_box='inbox' and m.message_type='Order' and m.status='PS' " />            
@@ -94,7 +94,7 @@
 		<!-- only for check the allowance of reset message -->    
 		<parameter type="finder" name="find_ordered_messages_by_message_box_and_cpa_and_status" value="select * from message where message_box=? and cpa_id=? and service=? and action=? and conv_id=? and status=? and sequence_no&lt;&gt;-1 LIMIT 1" />
 		
-		<parameter type="finder" name="find_message_by_history" value="select * from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
+		<parameter type="finder" name="find_message_by_history" value="select * from message where message_type = 'Order'" />
 		<parameter type="filter" name="find_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_message_id" value="message_id LIKE ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_cpa_id" value="cpa_id LIKE ?"/>
@@ -102,10 +102,9 @@
 		<parameter type="filter" name="find_message_by_history_filter_action" value="action LIKE ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_conv_id" value="conv_id LIKE ?"/>				
 		<parameter type="filter" name="find_message_by_history_filter_status" value="status = ?"/>
-		<parameter type="filter" name="find_message_by_history_filter_primal_message_id" value="primal_message_id LIKE ?"/>
 		<parameter type="order" name="find_message_by_history_order" value="order by time_stamp desc, message_box asc LIMIT ? offset ?"/>
 		
-		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
+		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where message_type = 'Order'" />
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_status" value="status = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_id" value="message_id LIKE ?"/>
@@ -113,7 +112,6 @@
 		<parameter type="filter" name="find_number_of_message_by_history_filter_service" value="service LIKE ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_action" value="action LIKE ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_conv_id" value="conv_id LIKE ?"/>
-		<parameter type="filter" name="find_number_of_message_by_history_filter_primal_message_id" value="primal_message_id LIKE ?"/>
 		<!-- <parameter type="filter" name="find_number_of_message_by_history_filter_status" value="status = ?"/> -->
 		
 		<!-- 
@@ -144,6 +142,20 @@
 		<parameter type="column" name="retried" value="retried" />
 		<parameter type="column" name="hostname" value="hostname" />
 		<parameter type="finder" name="select_outbox" value="select * from outbox" />
+	</dao>
+	
+	<dao name="hk.hku.cecid.ebms.spa.dao.ClusterDAO">
+		<class>hk.hku.cecid.ebms.spa.dao.ClusterDataSourceDAO</class>
+		<parameter name="table" value="cluster" />
+		<parameter name="key" value="hostname" />
+		<parameter type="column" name="hostname" value="hostname" />
+		<parameter type="column" name="status" value="status" />
+		<parameter type="column" name="timestamp" value="timestamp" />
+		<parameter type="finder" name="select_cluster" value="select * from cluster" />
+		<parameter type="finder" name="find_cluster_entry" value="select * from cluster where hostname = ?" />
+		<parameter type="finder" name="find_cluster_all_entries" value="select * from cluster" />
+		<parameter type="finder" name="find_cluster_latest_timestamp" value="select * from cluster where status = 'active' order by timestamp desc limit 1" />
+		<parameter type="finder" name="find_cluster_status_entries" value="select * from cluster where status = ?" />
 	</dao>
 	
 	<dao name="hk.hku.cecid.ebms.spa.dao.RepositoryDAO">

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.dao.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.dao.xml
@@ -66,14 +66,15 @@
 		<!-- <parameter type="column" name="principal_id" value="principalId" /> -->
 		<parameter type="column" name="status" value="status" />
 		<parameter type="column" name="status_description" value="statusDescription" />
+		<parameter type="column" name="hostname" value="hostname" />
 		
 		<parameter type="finder" name="get_all_before_time" value="select * from message where time_stamp &lt; ?" />
 		<parameter type="finder" name="find_ref_to_message" value="select * from message where ref_to_message_id=? and message_box=? and message_type=?" />			
 		
 		<!-- for inbox and outbox collector -->
-		<parameter type="finder" name="find_inbox_pending_messages_by_timestamp" value="select * from message where message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 50" />
-		<parameter type="finder" name="find_outbox_pending_messages_by_timestamp" value="select * from message,outbox where outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
-		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from message,outbox where outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
+		<parameter type="finder" name="find_inbox_pending_messages_by_timestamp" value="select * from message where hostname = ? and message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 50" />
+		<parameter type="finder" name="find_outbox_pending_messages_by_timestamp" value="select * from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
+		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from message,outbox where outbox.hostname = ? outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
 
 		<!-- only for Ebms Message Collector Service -->
 		<parameter type="finder" name="find_message_by_cpa" value="select m.* from message m, inbox i where m.message_id = i.message_id and m.cpa_id = ? and m.service = ? and m.action = ? and m.message_box='inbox' and m.message_type='Order' and m.status='PS' " />            
@@ -131,6 +132,7 @@
 		<parameter name="key" value="message_id" />
 		<parameter type="column" name="message_id" value="messageId" />
 		<parameter type="column" name="order_no" value="orderNo" />
+		<parameter type="column" name="hostname" value="hostname" />
 		<parameter type="finder" name="find_inbox_next_order_no" value="select nextval('inbox_order_no_seq')" />
 	</dao>
 
@@ -140,6 +142,7 @@
 		<parameter name="key" value="message_id" />
 		<parameter type="column" name="message_id" value="messageId" />
 		<parameter type="column" name="retried" value="retried" />
+		<parameter type="column" name="hostname" value="hostname" />
 		<parameter type="finder" name="select_outbox" value="select * from outbox" />
 	</dao>
 	

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.module-group.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.module-group.xml
@@ -23,4 +23,8 @@
    	  <class>hk.hku.cecid.ebms.spa.task.MessageMonitor</class>
    	  <descriptor>hk/hku/cecid/ebms/spa/conf/message-monitor.module.xml</descriptor>
     </module>	
+        <module>
+                <class>hk.hku.cecid.ebms.spa.task.EbmsEventModule</class>
+                <descriptor>hk/hku/cecid/ebms/spa/conf/ebms.module.event.xml</descriptor>
+        </module>
 </module-group>

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.module-group.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.module-group.xml
@@ -16,11 +16,11 @@
         <descriptor>hk/hku/cecid/ebms/spa/conf/mail-collector.module.xml</descriptor>
     </module>
     <module>
+        <class>hk.hku.cecid.ebms.spa.task.ClusterAudit</class>
+        <descriptor>hk/hku/cecid/ebms/spa/conf/cluster-audit.module.xml</descriptor>
+    </module>
+    <module>
    	  <class>hk.hku.cecid.ebms.spa.task.MessageMonitor</class>
    	  <descriptor>hk/hku/cecid/ebms/spa/conf/message-monitor.module.xml</descriptor>
-    </module>
-	<module>
-		<class>hk.hku.cecid.ebms.spa.task.EbmsEventModule</class>
-		<descriptor>hk/hku/cecid/ebms/spa/conf/ebms.module.event.xml</descriptor>
-	</module>
+    </module>	
 </module-group>

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.mysql.dao.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.mysql.dao.xml
@@ -66,14 +66,20 @@
 		<!-- <parameter type="column" name="principal_id" value="principalId" /> -->
 		<parameter type="column" name="status" value="status" />
 		<parameter type="column" name="status_description" value="statusDescription" />
+		<parameter type="column" name="hostname" value="hostname" />
 		
 		<parameter type="finder" name="get_all_before_time" value="select * from message where time_stamp &lt; ?" />
 		<parameter type="finder" name="find_ref_to_message" value="select * from message where ref_to_message_id=? and message_box=? and message_type=?" />			
 		
 		<!-- for inbox and outbox collector -->
-		<parameter type="finder" name="find_inbox_pending_messages_by_timestamp" value="select * from message where message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 50" />
-		<parameter type="finder" name="find_outbox_pending_messages_by_timestamp" value="select * from message where message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 50" />
-		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from message where message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 50" />
+		<parameter type="finder" name="find_inbox_pending_messages_by_timestamp" value="select * from message where hostname = ? and message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 50" />
+		<parameter type="finder" name="find_outbox_pending_messages_by_timestamp" value="select * from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
+		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 50" />
+
+		<!-- for Cluster Audit -->
+		<parameter type="sql" name="update_old_incoming_messages_pending_by_timestamp" value="update message set hostname = ? where message_id in (select message_id from message where hostname = ? and message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 25);" />
+		<parameter type="sql" name="update_old_outbox_pending_messages_by_timestamp" value="update outbox set hostname = ? where message_id in (select message.message_id from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp LIMIT 25)" />
+		<parameter type="sql" name="update_old_outbox_processing_messages_by_timestamp" value="update outbox set hostname = ? where message_id in (select message.message_id from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp LIMIT 25)" />
 
 		<!-- only for Ebms Message Collector Service -->
 		<parameter type="finder" name="find_message_by_cpa" value="select m.* from message m, inbox i where m.message_id = i.message_id and m.cpa_id = ? and m.service = ? and m.action = ? and m.message_box='inbox' and m.message_type='Order' and m.status='PS' " />            
@@ -93,7 +99,7 @@
 		<!-- only for check the allowance of reset message -->    
 		<parameter type="finder" name="find_ordered_messages_by_message_box_and_cpa_and_status" value="select * from message where message_box=? and cpa_id=? and service=? and action=? and conv_id=? and status=? and sequence_no&lt;&gt;-1 LIMIT 1" />
 		
-		<parameter type="finder" name="find_message_by_history" value="select * from message where message_type = 'Order'" />
+		<parameter type="finder" name="find_message_by_history" value="select * from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
 		<parameter type="filter" name="find_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_message_id" value="message_id LIKE ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_cpa_id" value="cpa_id LIKE ?"/>
@@ -104,7 +110,7 @@
 		<parameter type="filter" name="find_message_by_history_filter_primal_message_id" value="primal_message_id LIKE ?"/>
 		<parameter type="order" name="find_message_by_history_order" value="order by time_stamp desc,message_box asc LIMIT ? offset ?"/>
 		
-		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where message_type = 'Order'" />
+		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_status" value="status = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_id" value="message_id LIKE ?"/>
@@ -131,6 +137,7 @@
 		<parameter name="key" value="message_id" />
 		<parameter type="column" name="message_id" value="messageId" />
 		<parameter type="column" name="order_no" value="orderNo" />
+		<parameter type="column" name="hostname" value="hostname" />
 		<parameter type="finder" name="find_inbox_next_order_no" value="select max(order_no)+1 from inbox" />
 	</dao>
 			
@@ -140,9 +147,24 @@
 		<parameter name="key" value="message_id" />
 		<parameter type="column" name="message_id" value="messageId" />
 		<parameter type="column" name="retried" value="retried" />
+		<parameter type="column" name="hostname" value="hostname" />
 		<parameter type="finder" name="select_outbox" value="select * from outbox" />
 	</dao>
 
+	<dao name="hk.hku.cecid.ebms.spa.dao.ClusterDAO">
+		<class>hk.hku.cecid.ebms.spa.dao.ClusterDataSourceDAO</class>
+		<parameter name="table" value="cluster" />
+		<parameter name="key" value="hostname" />
+		<parameter type="column" name="hostname" value="hostname" />
+		<parameter type="column" name="status" value="status" />
+		<parameter type="column" name="timestamp" value="timestamp" />
+		<parameter type="finder" name="select_cluster" value="select * from cluster" />
+		<parameter type="finder" name="find_cluster_entry" value="select * from cluster where hostname = ?" />
+		<parameter type="finder" name="find_cluster_all_entries" value="select * from cluster" />
+		<parameter type="finder" name="find_cluster_latest_timestamp" value="select * from cluster where status = 'active' order by timestamp desc limit 1" />
+		<parameter type="finder" name="find_cluster_status_entries" value="select * from cluster where status = ?" />
+	</dao>
+	
 	<dao name="hk.hku.cecid.ebms.spa.dao.RepositoryDAO">
 		<class>hk.hku.cecid.ebms.spa.dao.RepositoryDataSourceDAO</class>
 		<parameter name="table" value="repository" />

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.oracle.dao.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.oracle.dao.xml
@@ -66,14 +66,20 @@
 		<!-- <parameter type="column" name="principal_id" value="principalId" /> -->
 		<parameter type="column" name="status" value="status" />
 		<parameter type="column" name="status_description" value="statusDescription" />
+		<parameter type="column" name="hostname" value="hostname" />
 
 		<parameter type="finder" name="get_all_before_time" value="select * from message where time_stamp &lt; ?" />
 		<parameter type="finder" name="find_ref_to_message" value="select * from message where ref_to_message_id=? and message_box=? and message_type=?" />			
 
 		<!-- for inbox and outbox collector -->
-		<parameter type="finder" name="find_inbox_pending_messages_by_timestamp" value="select * from (select * from message where message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp) where rownum&lt;=50" />
-		<parameter type="finder" name="find_outbox_pending_messages_by_timestamp" value="select * from (select * from message where message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp) where rownum&lt;=50" />
-		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from (select * from message where message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by time_stamp) where rownum&lt;=50" />
+		<parameter type="finder" name="find_inbox_pending_messages_by_timestamp" value="select * from (select * from message where hostname = ? and message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp) where rownum&lt;=50" />
+		<parameter type="finder" name="find_outbox_pending_messages_by_timestamp" value="select * from (select * from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp) where rownum&lt;=50" />
+		<parameter type="finder" name="find_outbox_processing_messages_by_timestamp" value="select * from (select * from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp) where rownum&lt;=50" />
+
+		<!-- for Cluster Audit -->
+		<parameter type="sql" name="update_old_incoming_messages_pending_by_timestamp" value="update message set hostname = ? where message_id in (select * from (select message_id from message where hostname = ? and message_box='inbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp) where rownum&lt;=25);" />
+		<parameter type="sql" name="update_old_outbox_pending_messages_by_timestamp" value="update outbox set hostname = ? where message_id in (select * from (select message.message_id from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PD' and message_type&lt;&gt;'ProcessedError' order by time_stamp) where rownum&lt;=25)" />
+		<parameter type="sql" name="update_old_outbox_processing_messages_by_timestamp" value="update outbox set hostname = ? where message_id in (select * from (select message.message_id from message,outbox where outbox.hostname = ? and outbox.message_id=message.message_id and message_box='outbox' and status='PR' and message_type&lt;&gt;'ProcessedError' order by retried,time_stamp) where rownum&lt;=25)" />
 
 		<!-- only for Ebms Message Collector Service -->
 		<parameter type="finder" name="find_message_by_cpa" value="select * from (select m.* from message m, inbox i where m.message_id = i.message_id and m.cpa_id = ? and m.service = ? and m.action = ? and m.message_box='inbox' and m.message_type='Order' and m.status='PS'"/>            
@@ -99,7 +105,7 @@
 		<parameter type="finder" name="find_no_of_messages_by_history" value="select count(message_id) from message where message_id like ? and message_box like ? and cpa_id like ? and service like ? and action like ? and conv_id like ? and status like ? and principal_id like ? and message_type = 'Order'" />
 -->
 
-		<parameter type="finder" name="find_message_by_history" value="select * from (select a.*, rownum rnum from (select * from message where message_type = 'Order'" />
+		<parameter type="finder" name="find_message_by_history" value="select * from (select a.*, rownum rnum from (select * from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
 		<parameter type="filter" name="find_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_message_id" value="message_id LIKE ?"/>
 		<parameter type="filter" name="find_message_by_history_filter_cpa_id" value="cpa_id LIKE ?"/>
@@ -110,7 +116,7 @@
 		<parameter type="filter" name="find_message_by_history_filter_primal_message_id" value="primal_message_id LIKE ?"/>
 		<parameter type="order" name="find_message_by_history_order" value="order by time_stamp desc, message_box asc) a where rownum &lt;= ?) where rnum &gt; ?"/>
 
-		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where message_type = 'Order'" />
+		<parameter type="finder" name="find_number_of_message_by_history" value="select count(message_id) from message where (message_type = 'Order' or message_type = 'Ping' or message_type = 'ProcessedError')" />
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_box" value="message_box = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_status" value="status = ?"/>
 		<parameter type="filter" name="find_number_of_message_by_history_filter_message_id" value="message_id LIKE ?"/>
@@ -136,6 +142,7 @@
 			<parameter name="key" value="message_id" />
 			<parameter type="column" name="message_id" value="messageId" />
 			<parameter type="column" name="order_no" value="orderNo" />
+			<parameter type="column" name="hostname" value="hostname" />
 			<parameter type="finder" name="find_inbox_next_order_no" value="select inbox_order_no_seq.nextval from dual" />
 	</dao>
 
@@ -145,9 +152,24 @@
 		<parameter name="key" value="message_id" />
 		<parameter type="column" name="message_id" value="messageId" />
 		<parameter type="column" name="retried" value="retried" />
+		<parameter type="column" name="hostname" value="hostname" />
 		<parameter type="finder" name="select_outbox" value="select * from outbox" />
 	</dao>
 
+	<dao name="hk.hku.cecid.ebms.spa.dao.ClusterDAO">
+		<class>hk.hku.cecid.ebms.spa.dao.ClusterDataSourceDAO</class>
+		<parameter name="table" value="cluster" />
+		<parameter name="key" value="hostname" />
+		<parameter type="column" name="hostname" value="hostname" />
+		<parameter type="column" name="status" value="status" />
+		<parameter type="column" name="timestamp" value="timestamp" />
+		<parameter type="finder" name="select_cluster" value="select * from cluster" />
+		<parameter type="finder" name="find_cluster_entry" value="select * from cluster where hostname = ?" />
+		<parameter type="finder" name="find_cluster_all_entries" value="select * from cluster" />
+		<parameter type="finder" name="find_cluster_latest_timestamp" value="select * from (select * from cluster where status = 'active' order by timestamp desc)) where rownum&lt;=1" />
+		<parameter type="finder" name="find_cluster_status_entries" value="select * from cluster where status = ?" />
+	</dao>
+	
 	<dao name="hk.hku.cecid.ebms.spa.dao.RepositoryDAO">
 		<class>hk.hku.cecid.ebms.spa.dao.RepositoryDataSourceDAO</class>
 		<parameter name="table" value="repository" />

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.properties.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.properties.xml
@@ -4,21 +4,21 @@
     <mail>
         <smtp>
             <enable>false</enable>
-            <host>${jentrata.smtp.host:localhost}</host>
+            <host>smtpout.cs.hku.hk</host>
             <protocol>smtp</protocol>
-            <port>${jentrata.smtp.port:25}</port>
-            <from_mail_address>${jentrata.smtp.from:}</from_mail_address>
-            <username>${jentrata.smtp.user:}</username>
-            <password>${jentrata.smtp.pass:}</password>
+            <port></port>
+            <from_mail_address></from_mail_address>
+            <username></username>
+            <password></password>
         </smtp>
         <pop>
             <enable>false</enable>            
-            <host>${jentrata.pop3.host:localhost}</host>
+            <host>mail.cecid.hku.hk</host>
             <protocol>pop3</protocol>
             <port></port>
             <folder>INBOX</folder>
-            <username>${jentrata.pop3.user:}</username>
-            <password>${jentrata.pop3.pass:}</password>
+            <username></username>
+            <password></password>
         </pop>
     </mail>
     <!-- Outbound agreement checking is used for client self-generated Ebxml Message -->
@@ -26,9 +26,11 @@
     <!-- Inbound agreement checking is optional for interop test -->
     <inbound_agreement_check>true</inbound_agreement_check>
     <!-- Sign header only is optional for interop test -->
-    <sign_header_only>false</sign_header_only>
-    <http_basic_auth>
-        <username>${jentrata.outbound.auth.username:}</username>
-        <password>${jentrata.outbound.auth.password:}</password>
-    </http_basic_auth>
+    <sign_header_only>false</sign_header_only>    
+    <cluster>
+      <port>8080</port>
+      <servlet>/corvus/httpd/ebms/inbound/</servlet>
+      <interval>120000</interval>
+      <connectiontimeout>10000</connectiontimeout>
+    </cluster>
 </ebms>

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.properties.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.properties.xml
@@ -4,21 +4,21 @@
     <mail>
         <smtp>
             <enable>false</enable>
-            <host>smtpout.cs.hku.hk</host>
+            <host>${jentrata.smtp.host:localhost}</host>
             <protocol>smtp</protocol>
-            <port></port>
-            <from_mail_address></from_mail_address>
-            <username></username>
-            <password></password>
+            <port>${jentrata.smtp.port:25}</port>
+            <from_mail_address>${jentrata.smtp.from:}</from_mail_address>
+            <username>${jentrata.smtp.user:}</username>
+            <password>${jentrata.smtp.pass:}</password>
         </smtp>
         <pop>
-            <enable>false</enable>            
-            <host>mail.cecid.hku.hk</host>
+            <enable>false</enable>
+            <host>${jentrata.pop3.host:localhost}</host>
             <protocol>pop3</protocol>
             <port></port>
             <folder>INBOX</folder>
-            <username></username>
-            <password></password>
+            <username>${jentrata.pop3.user:}</username>
+            <password>${jentrata.pop3.pass:}</password>
         </pop>
     </mail>
     <!-- Outbound agreement checking is used for client self-generated Ebxml Message -->
@@ -27,6 +27,10 @@
     <inbound_agreement_check>true</inbound_agreement_check>
     <!-- Sign header only is optional for interop test -->
     <sign_header_only>false</sign_header_only>    
+    <http_basic_auth>
+      <username>${jentrata.outbound.auth.username:}</username>
+      <password>${jentrata.outbound.auth.password:}</password>
+    </http_basic_auth>
     <cluster>
       <port>8080</port>
       <servlet>/corvus/httpd/ebms/inbound/</servlet>

--- a/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/message-monitor.module.xml
+++ b/Plugins/CorvusEbMS/src/main/resources/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/message-monitor.module.xml
@@ -1,4 +1,4 @@
-<module id="ebms.message-monitor" name="Ebms Plugin" version="1.0">
+<module id="ebms.message-monitor" name="Message Monitor" version="1.0">
     <parameters>
         <parameter name="execution-interval" value="5000" />
     </parameters>


### PR DESCRIPTION
These changes will allow Jentrata to run as a cluster. The cluster can
be build up out of several Jentrata instances on top of one Jentrata
database. In this version only Postgresql is supported, but changes in
the appropiate property files will allow to run it on top of other
DBMSes.

After installing this implementation make sure it will look at the
central postgresql database. This can be set in the property file:
./plugins/hk.hku.cecid.ebms/conf/hk/hku/cecid/ebms/spa/conf/ebms.module.
xml under the home directory of Jentrata. You need to change the line:
<parameter name="url" value="jdbc:postgresql://localhost:5432/ebms" />
by replacing 'localhost' into the address of the central postgresql
database.

Another important setting is to make sure the 'hostname' can be
translated into an ip address that's unique for the Jentrata server.