### PR TITLE
Remove DuplicateElimination from Acknowledgement

### DIFF
--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
@@ -122,9 +122,6 @@ public class SignalMessageGenerator {
 
         final MessageHeader messageHeader = ackMessage.getMessageHeader();
         messageHeader.setRefToMessageId(refToMessageId);
-        if (ackRequestedMessage.getDuplicateElimination()) {
-            messageHeader.setDuplicateElimination();
-        }
         Iterator toParties = ackRequestedMessage.getToPartyIds();
         if (toParties.hasNext()) {
             MessageHeader.PartyId party = (MessageHeader.PartyId) toParties


### PR DESCRIPTION
In the ebMS 2.0 standard it is not allowed to have a DuplicateElimination indicator in the Acknowledgement message. This change will update the method generateAcknowledgment by removing the lines that will add the DuplicateElimination indicator.