### PR TITLE
Make partnershipId more unique

### DIFF
--- a/Plugins/CorvusEbMS.Admin/src/main/java/hk/hku/cecid/ebms/admin/listener/AgreementUploadPageletAdaptor.java
+++ b/Plugins/CorvusEbMS.Admin/src/main/java/hk/hku/cecid/ebms/admin/listener/AgreementUploadPageletAdaptor.java
@@ -206,7 +206,7 @@ public class AgreementUploadPageletAdaptor extends AdminPageletAdaptor {
 
         String action = senderActionBinding.getAction();
 
-        partnershipDVO.setPartnershipId(cpa.getCpaid() + "," + channel.getChannelId() + "," + action);
+        partnershipDVO.setPartnershipId(cpa.getCpaid() + "," + channel.getChannelId() + "," + serviceName.replaceAll(" ", "") + "," + action);
         partnershipDVO.setCpaId(cpa.getCpaid());
         partnershipDVO.setService(serviceName);
         partnershipDVO.setAction(action);


### PR DESCRIPTION
This adds the `serviceName` as part of the partnershipId generated when importing CPA. Sometimes, some partnerships end up with the same generated partnershipId.

This will prevent missing partnerships from the CPA import.