### PR TITLE
Fix for Failed asynch acknowledgements handled incorrectly #8

### DIFF
--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/OutboundMessageProcessor.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/OutboundMessageProcessor.java
@@ -229,6 +229,7 @@ public class OutboundMessageProcessor {
 
 		MessageDVO messageDVO = message.getMessageDVO();
 		messageDVO.setStatus(MessageClassifier.INTERNAL_STATUS_PENDING);
+		messageDVO.setHostname(HostInfo.GetLocalhostAddress());
 		// update the sequence group
 		int currentMaxSequenceGroup = messageDAO
 				.findMaxSequenceGroupByMessageBoxAndCpa(messageDVO);
@@ -318,6 +319,7 @@ public class OutboundMessageProcessor {
 
 		MessageDVO messageDVO = message.getMessageDVO();
 		messageDVO.setStatus(MessageClassifier.INTERNAL_STATUS_PENDING);
+		messageDVO.setHostname(HostInfo.GetLocalhostAddress());
 		
 		if (null != primalMsgDVO) {
 			messageDVO.setPrimalMessageId(primalMsgDVO.getMessageId());

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/util/EbmsMessageStatusReverser.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/util/EbmsMessageStatusReverser.java
@@ -19,6 +19,7 @@ import hk.hku.cecid.piazza.commons.dao.DAOFactory;
 import hk.hku.cecid.piazza.commons.dao.ds.DataSourceDAO;
 import hk.hku.cecid.piazza.commons.dao.ds.DataSourceProcess;
 import hk.hku.cecid.piazza.commons.dao.ds.DataSourceTransaction;
+import hk.hku.cecid.piazza.commons.net.HostInfo;
 
 /**
  * Reverse message status for message redownload and resend
@@ -69,7 +70,8 @@ public class EbmsMessageStatusReverser {
 				messageDao.setTransaction(tx);
 
 				criteriaDVO.setStatus(MessageClassifier.INTERNAL_STATUS_PENDING);
-				criteriaDVO.setStatusDescription(null);
+				criteriaDVO.setHostname(HostInfo.GetLocalhostAddress());
+				criteriaDVO.setStatusDescription("Pending for re-send.");
 				messageDao.persist(criteriaDVO);
 
 				// Delete acknowledgement
@@ -97,6 +99,7 @@ public class EbmsMessageStatusReverser {
 				OutboxDVO outboxDVO = (OutboxDVO) outboxDAO.createDVO();
 				outboxDVO.setMessageId(messageId);
 				outboxDVO.setRetried(0);
+				outboxDVO.setHostname(HostInfo.GetLocalhostAddress());
 				outboxDAO.addOutbox(outboxDVO);
 			}
 		};


### PR DESCRIPTION
The changes made in this request will correct the behaviour of Jentrata concerning re-sends of Acknowledgements and user-messages. The problem that was described in issue #8.

The problem was caused by the incomplete registration of PENDING messages. As a result messages (and acknowledgements) were not picked up by the OutboxCollector process. The changes proposed here will complete all registrations of PENDING messages in a way that the OutboxCollector process will pick them and thereby the messages are actually re-send.