### PR TITLE
#62 Remove DuplicateElimination from Acknowledgement

### DIFF
--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
@@ -122,9 +122,7 @@ public class SignalMessageGenerator {
 
         final MessageHeader messageHeader = ackMessage.getMessageHeader();
         messageHeader.setRefToMessageId(refToMessageId);
-        if (ackRequestedMessage.getDuplicateElimination()) {
-            messageHeader.setDuplicateElimination();
-        }
+
         Iterator toParties = ackRequestedMessage.getToPartyIds();
         if (toParties.hasNext()) {
             MessageHeader.PartyId party = (MessageHeader.PartyId) toParties


### PR DESCRIPTION
This is the change needed for issue #62 Remove DuplicateElimination from Acknowledgement. The original code result in compatibility problems with a number of ebMS v2.0 implementations. Since the addition of the DuplicateElimination setting as part of the acknowledgement is not allowed as stated in the ebMS v2.0 standard provided by OASIS this should be removed from Jentrata.