### PR TITLE
Changes for issue #63 add messageid as option client

### DIFF
--- a/ContainerFiles/initdb.sh
+++ b/ContainerFiles/initdb.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -ex
 
-psql --username postgres <<-EOSQL
+psql --username jentrata <<-EOSQL
     CREATE USER "$DB_USER_NAME" WITH SUPERUSER PASSWORD '$DB_USER_PASS' ;
 EOSQL
 
-psql --username postgres <<-EOSQL
+psql --username jentrata <<-EOSQL
     CREATE DATABASE ebms ;
     CREATE DATABASE as2 ;
 EOSQL
 
-cat  /work/sql/ebms.sql | psql --username postgres ebms
-cat  /work/sql/as2.sql | psql --username postgres as2
+cat  /work/sql/ebms.sql | psql --username jentrata ebms
+cat  /work/sql/as2.sql | psql --username jentrata as2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM jentrata/jenrata-msh:tomcat9
+FROM jentrata/jentrata-msh
 MAINTAINER Arran Ubels a.ubels@base2services.com
 
 #install jdk to allow remote debugging
 RUN apt-get update --fix-missing && \
-    apt-get install -y openjdk-${JDK_VERSION}-jdk && \
+#    apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     rm -rf /var/lib/apt/lists/*
 
 ENV JENTRATA_VERSION 3.x-SNAPSHOT

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
@@ -122,9 +122,7 @@ public class SignalMessageGenerator {
 
         final MessageHeader messageHeader = ackMessage.getMessageHeader();
         messageHeader.setRefToMessageId(refToMessageId);
-        if (ackRequestedMessage.getDuplicateElimination()) {
-            messageHeader.setDuplicateElimination();
-        }
+        
         Iterator toParties = ackRequestedMessage.getToPartyIds();
         if (toParties.hasNext()) {
             MessageHeader.PartyId party = (MessageHeader.PartyId) toParties

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/service/EbmsMessageSenderService.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/service/EbmsMessageSenderService.java
@@ -66,6 +66,7 @@ public class EbmsMessageSenderService extends WebServicesAdaptor {
         String refToMessageId = getText(bodies, "refToMessageId");
         String fromPartyRole = getText(bodies, "fromPartyRole");
         String toPartyRole = getText(bodies, "toPartyRole");
+        String messageId = getText(bodies, "messageId");
 
         if (cpaId == null || service == null || action == null
                 || convId == null || fromPartyId == null
@@ -102,11 +103,11 @@ public class EbmsMessageSenderService extends WebServicesAdaptor {
                 + ", toPartyId: "	  + toPartyId
                 + ", toPartyType: " + toPartyType
                 + ", toPartyRole: " + toPartyRole
-                + ", refToMessageId: " + refToMessageId);
+                + ", refToMessageId: " + refToMessageId
+                + ", messageId: " + messageId);
 
         // Construct Ebxml message
         EbxmlMessage ebxmlMessage = null;
-        String messageId = null;
         try {
             ebxmlMessage = new EbxmlMessage();
             MessageHeader msgHeader = ebxmlMessage.addMessageHeader();
@@ -119,10 +120,12 @@ public class EbmsMessageSenderService extends WebServicesAdaptor {
             if (serviceType != null && !serviceType.equals("")) {
             	msgHeader.setServiceType(serviceType);
             }
-            
-            messageId = Generator.generateMessageID();
+
+            if (messageId == null || messageId.equals("")) {
+                messageId = Generator.generateMessageID();
+                EbmsProcessor.core.log.info("Generated message id: " + messageId);
+            }
             ebxmlMessage.getMessageHeader().setMessageId(messageId);
-            EbmsProcessor.core.log.info("Genereating message id: " + messageId);
 
             msgHeader.setTimestamp(EbmsUtility.getCurrentUTCDateTime());
             

--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/service/EbmsMessageSenderService.wsdl
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/service/EbmsMessageSenderService.wsdl
@@ -24,6 +24,7 @@
   <part name="toPartyRole" type="s:string" />
   <part name="refToMessageId" type="s:string" />
   <part name="serviceType" type="s:string" />
+  <part name="messageId" type="s:string" />
 </message>
 <message name="EbmsResponseMsg">
   <part name="message_id" type="s:string" /> 


### PR DESCRIPTION
This change adds an option for WS clients to provide a messageId for the ebMS message to be sent by the Jentrata server. This change is backwards compatible and is tested with the sample client built in a previous version.